### PR TITLE
Fix matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ os: osx
 osx_image: xcode6.4
 
 env:
+  matrix:
+    
+    - CONDA_PY=27
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     - secure: "pJEQNfZQ836VFq3YLZLSXiwp/pPCep2yM2/U6RTSeiyxwc5F9wCd1sSYm9ZEngWZZHjJJ/ZRRtHKGA4gEa9R/9/bd3QCD8yYoUar56zRQMFTRyhnlqpYP2OZU5P1XXcaB9Nsx2u2pMXAgvCT4u4Lkmwn247Y2cqgRnlkQx3Y7MMstkrhnmF9ESOVaq9hH80Kd5TF/Ll56kosJNEe2intKOT5gdR/grDbS1tFlG2OR25EpBMxj0oWLSfm8ClSFaMNOeoj0SYb/+FQ0C/C+GvpiIsUMdqw1M52jh3LmU13xatwrnm7oZRwWhJqjhrKYPFb151qNlXmckX6lPuiiBHrK7NIOnlGFHsN6V9AGepSbFF2bM2OV/wngmXZZ8C6lekfVXcrmkxBZvgrf2iCc8CcRyFNtWSadUd9+i+Cnph3utL+AuuTgxVV0wzxmW/sA1x/E+mtcKXGaiUOlXhRhlmSOtvux/AeBqEMCLMFbGv75Br6H44RKN2jHRjRaFb5Ecbpo7fQRXoQfItSwiGxZpJasv+1MrTvAjGnxCb069gALMuc2PqKVUjQX7oSr5a9FQfkEENwzgDx2XptOYr4K0woFwP6ZXMQNUr3iuS5pPH2Fj2cFa6qOCBY8m+TCeR8WfDdUiQVkf3Fu0aCc6P54tswkTWbmArGD+P3DJIgCtMSJ5o="

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -44,6 +44,9 @@ conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
 
 # Embarking on 1 case(s).
+    set -x
+    export CONDA_PY=27
+    set +x
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
 touch /feedstock_root/build_artefacts/conda-forge-build-done


### PR DESCRIPTION
Latest `conda-smithy` is broken since it re-renders even when the packages are unavailable and that is resulting in false builds.